### PR TITLE
Link to CC-0 in license statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ There is also http://whatcanidoforwikimedia.org/ maintained by other user(s). In
 
 Not officially affiliated with the Wikimedia Foundation (they have no control over the content). But of course, we notified them about this.
 
-You are invited to contribute :-) By contributing you release your codes into the public domain.
+You are invited to contribute :-) By contributing you release your codes into the [public domain](https://creativecommons.org/publicdomain/zero/1.0/).
 
 # Edit
 * Mainpage: index.php


### PR DESCRIPTION
"public domain" is legally ambiguous, so explicitly specify CC-0 as the license.
